### PR TITLE
Various improvements

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.12)
 project("Sakurai" C)
 
 if (MSVC)

--- a/source/engine-sdl/cache.c
+++ b/source/engine-sdl/cache.c
@@ -248,10 +248,13 @@ int CacheTest()
 
 	struct Cache* c = CacheCreate(4);
 
-	assert(((i1 = CacheAdd(c, "spr1", 1, NULL)) != NULL)); // Success
-	assert(((i2 = CacheAdd(c, "spr2", 1, NULL)) != NULL)); // Success
+	i1 = CacheAdd(c, "spr1", 1, NULL);
+	assert((i1 != NULL));                                  // Success
+	i2 = CacheAdd(c, "spr2", 1, NULL);
+	assert((i2 != NULL));                                  // Success
 	assert((CacheAdd(c, "spr3", 1, NULL) != NULL));        // Success
-	assert(((i4 = CacheAdd(c, "spr4", 1, NULL)) != NULL)); // Success
+	i4 = CacheAdd(c, "spr4", 1, NULL);
+	assert((i4 != NULL));                                 // Success
 	assert((CacheAdd(c, "spr5", 1, NULL) == NULL));        // Failure, limit of 4 reached
 	assert((CacheAdd(c, "spr4", 1, NULL) == NULL));        // Failure, already in cache
 


### PR DESCRIPTION
Hello,
I tried to compile your game on Ubuntu 18.04 LTS but I found that cmake 3.10 does not support ```add_compile_definitions```. This function was introduced in cmake 3.12. So, I fixed the cmake minimum version.
I also found that cppcheck reported variable assignments in some asserts.